### PR TITLE
Update cesium_widget.js

### DIFF
--- a/CesiumWidget/cesium_widget.js
+++ b/CesiumWidget/cesium_widget.js
@@ -207,7 +207,7 @@ define(
 					            roll : Cesium.Math.toRadians(Number(pos[5]))
 					        }
 					    });
-					this.model.set('_flyto', null);
+					//this.model.set('_flyto', null);
 					this.touch()
 				}
 				console.log(pos);
@@ -226,7 +226,7 @@ define(
 					        pitch : Cesium.Math.toRadians(Number(pos[4])),
 					        roll : Cesium.Math.toRadians(Number(pos[5]))
 					    });
-					    this.model.set('_zoomto', null);
+					    //this.model.set('_zoomto', null);
 					    this.touch()
 				}
 				console.log(pos);


### PR DESCRIPTION
Backbone 'on change' is preventing the re-running of the same action when the input parameters are not changing:

```
this.fly_to();
this.model.on('change:_flyto', this.fly_to, this);
this.zoom_to();
this.model.on('change:_zoomto', this.zoom_to, this);
```

the attempt to fir this setting to null  the var `_zoomto` and `_flyto` doesn't fix the issue and make the vars not available at first run. 

reverting the changes `this.model.set('_zoomto', null);` and `this.model.set('_flyto', null);`
